### PR TITLE
Include tests in sdist archives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Topic :: Software Development :: Libraries"
 ]
+include = [
+    {path = "tests", format = "sdist"},
+]
 
 [tool.poetry.dependencies]
 jsonschema = "^4.0.0"


### PR DESCRIPTION
Include the "tests" directory in sdist archives, to permit Linux distributions to use these archives instead of GitHub snapshots that are not reliable long-term.