### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-default_stages: [commit, push]
+default_stages: [pre-commit, pre-push]
 default_language_version:
   # force all unspecified python hooks to run python3
   python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,7 @@ repos:
     hooks:
       - id: isort
 
-  - repo: local
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
     hooks:
-      - id: pyflakes
-        name: pyflakes
-        entry: pyflakes
-        language: system
-        require_serial: true
-        types: [python]
+      - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: flynt
-        name: Convert to f-strings with flynt
-        entry: flynt
-        language: python
-        additional_dependencies: ['flynt==0.76']
-
       - id: black
         name: black
         entry: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-hooks-apply
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.0
+    rev: v3.20.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,16 +20,13 @@ repos:
     hooks:
       - id: black
 
-  - repo: local
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
     hooks:
       - id: isort
-        name: isort
-        entry: isort
-        args: ['--filter-files']
-        language: system
-        require_serial: true
-        types: [python]
 
+  - repo: local
+    hooks:
       - id: pyflakes
         name: pyflakes
         entry: pyflakes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,15 +15,13 @@ repos:
       - id: pyupgrade
         args: ["--py39-plus"]
 
-  - repo: local
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.1.0
     hooks:
       - id: black
-        name: black
-        entry: black
-        language: system
-        require_serial: true
-        types: [python]
 
+  - repo: local
+    hooks:
       - id: isort
         name: isort
         entry: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v3.20.0
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py39-plus"]
 
   - repo: local
     hooks:

--- a/openapi_spec_validator/__init__.py
+++ b/openapi_spec_validator/__init__.py
@@ -1,4 +1,5 @@
 """OpenAPI spec validator module."""
+
 from openapi_spec_validator.shortcuts import validate
 from openapi_spec_validator.shortcuts import validate_spec
 from openapi_spec_validator.shortcuts import validate_spec_url

--- a/openapi_spec_validator/__main__.py
+++ b/openapi_spec_validator/__main__.py
@@ -1,8 +1,8 @@
 import logging
 import sys
 from argparse import ArgumentParser
-from typing import Optional
 from collections.abc import Sequence
+from typing import Optional
 
 from jsonschema.exceptions import ValidationError
 from jsonschema.exceptions import best_match

--- a/openapi_spec_validator/__main__.py
+++ b/openapi_spec_validator/__main__.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from argparse import ArgumentParser
 from typing import Optional
-from typing import Sequence
+from collections.abc import Sequence
 
 from jsonschema.exceptions import ValidationError
 from jsonschema.exceptions import best_match

--- a/openapi_spec_validator/readers.py
+++ b/openapi_spec_validator/readers.py
@@ -8,11 +8,11 @@ from jsonschema_path.handlers import file_handler
 from jsonschema_path.typing import Schema
 
 
-def read_from_stdin(filename: str) -> Tuple[Schema, str]:
+def read_from_stdin(filename: str) -> tuple[Schema, str]:
     return file_handler(sys.stdin), ""  # type: ignore
 
 
-def read_from_filename(filename: str) -> Tuple[Schema, str]:
+def read_from_filename(filename: str) -> tuple[Schema, str]:
     if not path.isfile(filename):
         raise OSError(f"No such file: {filename}")
 

--- a/openapi_spec_validator/readers.py
+++ b/openapi_spec_validator/readers.py
@@ -1,7 +1,6 @@
 import sys
 from os import path
 from pathlib import Path
-from typing import Tuple
 
 from jsonschema_path.handlers import all_urls_handler
 from jsonschema_path.handlers import file_handler

--- a/openapi_spec_validator/schemas/__init__.py
+++ b/openapi_spec_validator/schemas/__init__.py
@@ -1,4 +1,5 @@
 """OpenAIP spec validator schemas module."""
+
 from functools import partial
 
 from jsonschema.validators import Draft4Validator

--- a/openapi_spec_validator/schemas/utils.py
+++ b/openapi_spec_validator/schemas/utils.py
@@ -8,7 +8,7 @@ from jsonschema_path.readers import FilePathReader
 from jsonschema_path.typing import Schema
 
 
-def get_schema(version: str) -> Tuple[Schema, str]:
+def get_schema(version: str) -> tuple[Schema, str]:
     schema_path = f"resources/schemas/v{version}/schema.json"
     ref = files("openapi_spec_validator") / schema_path
     with as_file(ref) as resource_path:

--- a/openapi_spec_validator/schemas/utils.py
+++ b/openapi_spec_validator/schemas/utils.py
@@ -3,7 +3,6 @@
 from importlib.resources import as_file
 from importlib.resources import files
 from os import path
-from typing import Tuple
 
 from jsonschema_path.readers import FilePathReader
 from jsonschema_path.typing import Schema

--- a/openapi_spec_validator/schemas/utils.py
+++ b/openapi_spec_validator/schemas/utils.py
@@ -1,4 +1,5 @@
 """OpenAIP spec validator schemas utils module."""
+
 from importlib.resources import as_file
 from importlib.resources import files
 from os import path

--- a/openapi_spec_validator/shortcuts.py
+++ b/openapi_spec_validator/shortcuts.py
@@ -3,7 +3,6 @@
 import warnings
 from collections.abc import Mapping
 from typing import Optional
-from typing import Type
 
 from jsonschema_path import SchemaPath
 from jsonschema_path.handlers import all_urls_handler

--- a/openapi_spec_validator/shortcuts.py
+++ b/openapi_spec_validator/shortcuts.py
@@ -1,6 +1,6 @@
 """OpenAPI spec validator shortcuts module."""
 import warnings
-from typing import Mapping
+from collections.abc import Mapping
 from typing import Optional
 from typing import Type
 
@@ -50,7 +50,7 @@ def validate(
 
 def validate_url(
     spec_url: str,
-    cls: Optional[Type[SpecValidator]] = None,
+    cls: Optional[type[SpecValidator]] = None,
 ) -> None:
     spec = all_urls_handler(spec_url)
     return validate(spec, base_uri=spec_url, cls=cls)
@@ -82,7 +82,7 @@ def validate_spec(
 def validate_spec_url(
     spec_url: str,
     validator: Optional[SupportsValidation] = None,
-    cls: Optional[Type[SpecValidator]] = None,
+    cls: Optional[type[SpecValidator]] = None,
 ) -> None:
     warnings.warn(
         "validate_spec_url shortcut is deprecated. Use validate_url instead.",

--- a/openapi_spec_validator/shortcuts.py
+++ b/openapi_spec_validator/shortcuts.py
@@ -1,4 +1,5 @@
 """OpenAPI spec validator shortcuts module."""
+
 import warnings
 from collections.abc import Mapping
 from typing import Optional

--- a/openapi_spec_validator/validation/caches.py
+++ b/openapi_spec_validator/validation/caches.py
@@ -1,6 +1,6 @@
 from typing import Generic
-from typing import Iterable
-from typing import Iterator
+from collections.abc import Iterable
+from collections.abc import Iterator
 from typing import List
 from typing import TypeVar
 
@@ -14,7 +14,7 @@ class CachedIterable(Iterable[T], Generic[T]):
     It should not be iterated by his own.
     """
 
-    cache: List[T]
+    cache: list[T]
     iter: Iterator[T]
     completed: bool
 

--- a/openapi_spec_validator/validation/caches.py
+++ b/openapi_spec_validator/validation/caches.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 from collections.abc import Iterator
 from typing import Generic
-from typing import List
 from typing import TypeVar
 
 T = TypeVar("T")

--- a/openapi_spec_validator/validation/caches.py
+++ b/openapi_spec_validator/validation/caches.py
@@ -1,6 +1,6 @@
-from typing import Generic
 from collections.abc import Iterable
 from collections.abc import Iterator
+from typing import Generic
 from typing import List
 from typing import TypeVar
 

--- a/openapi_spec_validator/validation/decorators.py
+++ b/openapi_spec_validator/validation/decorators.py
@@ -1,4 +1,5 @@
 """OpenAPI spec validator validation decorators module."""
+
 import logging
 from functools import wraps
 from typing import Any
@@ -19,7 +20,7 @@ log = logging.getLogger(__name__)
 
 
 def wraps_errors(
-    func: Callable[..., Any]
+    func: Callable[..., Any],
 ) -> Callable[..., Iterator[ValidationError]]:
     @wraps(func)
     def wrapper(*args: Any, **kwds: Any) -> Iterator[ValidationError]:
@@ -35,7 +36,7 @@ def wraps_errors(
 
 
 def wraps_cached_iter(
-    func: Callable[[Args], Iterator[T]]
+    func: Callable[[Args], Iterator[T]],
 ) -> Callable[[Args], CachedIterable[T]]:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> CachedIterable[T]:
@@ -46,7 +47,7 @@ def wraps_cached_iter(
 
 
 def unwraps_iter(
-    func: Callable[[Args], Iterable[T]]
+    func: Callable[[Args], Iterable[T]],
 ) -> Callable[[Args], Iterator[T]]:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Iterator[T]:

--- a/openapi_spec_validator/validation/decorators.py
+++ b/openapi_spec_validator/validation/decorators.py
@@ -3,8 +3,8 @@ import logging
 from functools import wraps
 from typing import Any
 from typing import Callable
-from typing import Iterable
-from typing import Iterator
+from collections.abc import Iterable
+from collections.abc import Iterator
 from typing import TypeVar
 
 from jsonschema.exceptions import ValidationError

--- a/openapi_spec_validator/validation/decorators.py
+++ b/openapi_spec_validator/validation/decorators.py
@@ -1,11 +1,11 @@
 """OpenAPI spec validator validation decorators module."""
 
 import logging
+from collections.abc import Iterable
+from collections.abc import Iterator
 from functools import wraps
 from typing import Any
 from typing import Callable
-from collections.abc import Iterable
-from collections.abc import Iterator
 from typing import TypeVar
 
 from jsonschema.exceptions import ValidationError

--- a/openapi_spec_validator/validation/keywords.py
+++ b/openapi_spec_validator/validation/keywords.py
@@ -1,8 +1,8 @@
 import string
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Sequence
-from typing import Iterator
+from collections.abc import Sequence
+from collections.abc import Iterator
 from typing import List
 from typing import Optional
 from typing import cast
@@ -68,7 +68,7 @@ class SchemaValidator(KeywordValidator):
     def __init__(self, registry: "KeywordValidatorRegistry"):
         super().__init__(registry)
 
-        self.schema_ids_registry: Optional[List[int]] = []
+        self.schema_ids_registry: Optional[list[int]] = []
 
     @property
     def default_validator(self) -> ValueValidator:
@@ -305,7 +305,7 @@ class OperationValidator(KeywordValidator):
     def __init__(self, registry: "KeywordValidatorRegistry"):
         super().__init__(registry)
 
-        self.operation_ids_registry: Optional[List[str]] = []
+        self.operation_ids_registry: Optional[list[str]] = []
 
     @property
     def responses_validator(self) -> ResponsesValidator:
@@ -356,8 +356,7 @@ class OperationValidator(KeywordValidator):
         for path in self._get_path_params_from_url(url):
             if path not in all_params:
                 yield UnresolvableParameterError(
-                    "Path parameter '{}' for '{}' operation in '{}' "
-                    "was not resolved".format(path, name, url)
+                    f"Path parameter '{path}' for '{name}' operation in '{url}' was not resolved"
                 )
         return
 

--- a/openapi_spec_validator/validation/keywords.py
+++ b/openapi_spec_validator/validation/keywords.py
@@ -1,8 +1,8 @@
 import string
+from collections.abc import Iterator
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 from typing import Any
-from collections.abc import Sequence
-from collections.abc import Iterator
 from typing import List
 from typing import Optional
 from typing import cast

--- a/openapi_spec_validator/validation/keywords.py
+++ b/openapi_spec_validator/validation/keywords.py
@@ -113,8 +113,9 @@ class SchemaValidator(KeywordValidator):
             all_of = schema / "allOf"
             for inner_schema in all_of:
                 yield from self(inner_schema, require_properties=False)
-                nested_properties += list(self._collect_properties(inner_schema))
-
+                nested_properties += list(
+                    self._collect_properties(inner_schema)
+                )
 
         if "anyOf" in schema:
             any_of = schema / "anyOf"
@@ -154,8 +155,12 @@ class SchemaValidator(KeywordValidator):
                     require_properties=False,
                 )
 
-        required = "required" in schema and (schema / "required").read_value() or []
-        properties = "properties" in schema and (schema / "properties").keys() or []
+        required = (
+            "required" in schema and (schema / "required").read_value() or []
+        )
+        properties = (
+            "properties" in schema and (schema / "properties").keys() or []
+        )
         if "allOf" in schema:
             extra_properties = list(
                 set(required) - set(properties) - set(nested_properties)

--- a/openapi_spec_validator/validation/keywords.py
+++ b/openapi_spec_validator/validation/keywords.py
@@ -3,7 +3,6 @@ from collections.abc import Iterator
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import List
 from typing import Optional
 from typing import cast
 

--- a/openapi_spec_validator/validation/protocols.py
+++ b/openapi_spec_validator/validation/protocols.py
@@ -10,21 +10,18 @@ from openapi_spec_validator.validation.exceptions import OpenAPIValidationError
 
 @runtime_checkable
 class SupportsValidation(Protocol):
-    def is_valid(self, instance: Schema) -> bool:
-        ...
+    def is_valid(self, instance: Schema) -> bool: ...
 
     def iter_errors(
         self,
         instance: Schema,
         base_uri: str = "",
         spec_url: Optional[str] = None,
-    ) -> Iterator[OpenAPIValidationError]:
-        ...
+    ) -> Iterator[OpenAPIValidationError]: ...
 
     def validate(
         self,
         instance: Schema,
         base_uri: str = "",
         spec_url: Optional[str] = None,
-    ) -> None:
-        ...
+    ) -> None: ...

--- a/openapi_spec_validator/validation/protocols.py
+++ b/openapi_spec_validator/validation/protocols.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from collections.abc import Iterator
 from typing import Optional
 from typing import Protocol
 from typing import runtime_checkable

--- a/openapi_spec_validator/validation/proxies.py
+++ b/openapi_spec_validator/validation/proxies.py
@@ -1,12 +1,9 @@
 """OpenAPI spec validator validation proxies module."""
 
 import warnings
-from collections.abc import Hashable
 from collections.abc import Iterator
 from collections.abc import Mapping
-from typing import Any
 from typing import Optional
-from typing import Tuple
 
 from jsonschema.exceptions import ValidationError
 from jsonschema_path.typing import Schema

--- a/openapi_spec_validator/validation/proxies.py
+++ b/openapi_spec_validator/validation/proxies.py
@@ -1,4 +1,5 @@
 """OpenAPI spec validator validation proxies module."""
+
 import warnings
 from collections.abc import Hashable
 from typing import Any

--- a/openapi_spec_validator/validation/proxies.py
+++ b/openapi_spec_validator/validation/proxies.py
@@ -2,8 +2,8 @@
 import warnings
 from collections.abc import Hashable
 from typing import Any
-from typing import Iterator
-from typing import Mapping
+from collections.abc import Iterator
+from collections.abc import Mapping
 from typing import Optional
 from typing import Tuple
 
@@ -59,7 +59,7 @@ class SpecValidatorProxy:
 
 
 class DetectValidatorProxy:
-    def __init__(self, choices: Mapping[Tuple[str, str], SpecValidatorProxy]):
+    def __init__(self, choices: Mapping[tuple[str, str], SpecValidatorProxy]):
         self.choices = choices
 
     def detect(self, instance: Schema) -> SpecValidatorProxy:

--- a/openapi_spec_validator/validation/proxies.py
+++ b/openapi_spec_validator/validation/proxies.py
@@ -2,9 +2,9 @@
 
 import warnings
 from collections.abc import Hashable
-from typing import Any
 from collections.abc import Iterator
 from collections.abc import Mapping
+from typing import Any
 from typing import Optional
 from typing import Tuple
 

--- a/openapi_spec_validator/validation/registries.py
+++ b/openapi_spec_validator/validation/registries.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import DefaultDict
-from typing import Type
 
 from openapi_spec_validator.validation.keywords import KeywordValidator
 

--- a/openapi_spec_validator/validation/registries.py
+++ b/openapi_spec_validator/validation/registries.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import DefaultDict
-from typing import Mapping
+from collections.abc import Mapping
 from typing import Type
 
 from openapi_spec_validator.validation.keywords import KeywordValidator
@@ -9,7 +9,7 @@ from openapi_spec_validator.validation.keywords import KeywordValidator
 
 class KeywordValidatorRegistry(DefaultDict[str, KeywordValidator]):
     def __init__(
-        self, keyword_validators: Mapping[str, Type[KeywordValidator]]
+        self, keyword_validators: Mapping[str, type[KeywordValidator]]
     ):
         super().__init__()
         self.keyword_validators = keyword_validators

--- a/openapi_spec_validator/validation/registries.py
+++ b/openapi_spec_validator/validation/registries.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import DefaultDict
 from collections.abc import Mapping
+from typing import DefaultDict
 from typing import Type
 
 from openapi_spec_validator.validation.keywords import KeywordValidator

--- a/openapi_spec_validator/validation/types.py
+++ b/openapi_spec_validator/validation/types.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from openapi_spec_validator.validation.validators import SpecValidator
 
 SpecValidatorType = type[SpecValidator]

--- a/openapi_spec_validator/validation/types.py
+++ b/openapi_spec_validator/validation/types.py
@@ -2,4 +2,4 @@ from typing import Type
 
 from openapi_spec_validator.validation.validators import SpecValidator
 
-SpecValidatorType = Type[SpecValidator]
+SpecValidatorType = type[SpecValidator]

--- a/openapi_spec_validator/validation/validators.py
+++ b/openapi_spec_validator/validation/validators.py
@@ -5,9 +5,7 @@ import warnings
 from collections.abc import Iterator
 from collections.abc import Mapping
 from functools import lru_cache
-from typing import List
 from typing import Optional
-from typing import Type
 from typing import cast
 
 from jsonschema.exceptions import ValidationError

--- a/openapi_spec_validator/validation/validators.py
+++ b/openapi_spec_validator/validation/validators.py
@@ -2,9 +2,9 @@
 import logging
 import warnings
 from functools import lru_cache
-from typing import Iterator
+from collections.abc import Iterator
 from typing import List
-from typing import Mapping
+from collections.abc import Mapping
 from typing import Optional
 from typing import Type
 from typing import cast
@@ -31,10 +31,10 @@ log = logging.getLogger(__name__)
 
 class SpecValidator:
     resolver_handlers = default_handlers
-    keyword_validators: Mapping[str, Type[keywords.KeywordValidator]] = {
+    keyword_validators: Mapping[str, type[keywords.KeywordValidator]] = {
         "__root__": keywords.RootValidator,
     }
-    root_keywords: List[str] = []
+    root_keywords: list[str] = []
     schema_validator: Validator = NotImplemented
 
     def __init__(

--- a/openapi_spec_validator/validation/validators.py
+++ b/openapi_spec_validator/validation/validators.py
@@ -1,4 +1,5 @@
 """OpenAPI spec validator validation validators module."""
+
 import logging
 import warnings
 from functools import lru_cache

--- a/openapi_spec_validator/validation/validators.py
+++ b/openapi_spec_validator/validation/validators.py
@@ -2,10 +2,10 @@
 
 import logging
 import warnings
-from functools import lru_cache
 from collections.abc import Iterator
-from typing import List
 from collections.abc import Mapping
+from functools import lru_cache
+from typing import List
 from typing import Optional
 from typing import Type
 from typing import cast

--- a/openapi_spec_validator/versions/consts.py
+++ b/openapi_spec_validator/versions/consts.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from openapi_spec_validator.versions.datatypes import SpecVersion
 
 OPENAPIV2 = SpecVersion(

--- a/openapi_spec_validator/versions/consts.py
+++ b/openapi_spec_validator/versions/consts.py
@@ -20,4 +20,4 @@ OPENAPIV31 = SpecVersion(
     minor="1",
 )
 
-VERSIONS: List[SpecVersion] = [OPENAPIV2, OPENAPIV30, OPENAPIV31]
+VERSIONS: list[SpecVersion] = [OPENAPIV2, OPENAPIV30, OPENAPIV31]

--- a/openapi_spec_validator/versions/finders.py
+++ b/openapi_spec_validator/versions/finders.py
@@ -1,5 +1,4 @@
 from re import compile
-from typing import List
 
 from jsonschema_path.typing import Schema
 

--- a/openapi_spec_validator/versions/finders.py
+++ b/openapi_spec_validator/versions/finders.py
@@ -10,7 +10,7 @@ from openapi_spec_validator.versions.exceptions import OpenAPIVersionNotFound
 class SpecVersionFinder:
     pattern = compile(r"(?P<major>\d+)\.(?P<minor>\d+)(\..*)?")
 
-    def __init__(self, versions: List[SpecVersion]) -> None:
+    def __init__(self, versions: list[SpecVersion]) -> None:
         self.versions = versions
 
     def find(self, spec: Schema) -> SpecVersion:

--- a/tests/integration/validation/test_exceptions.py
+++ b/tests/integration/validation/test_exceptions.py
@@ -3,7 +3,6 @@ from openapi_spec_validator import OpenAPIV30SpecValidator
 from openapi_spec_validator.validation.exceptions import (
     DuplicateOperationIDError,
 )
-from openapi_spec_validator.validation.exceptions import ExtraParametersError
 from openapi_spec_validator.validation.exceptions import OpenAPIValidationError
 from openapi_spec_validator.validation.exceptions import (
     UnresolvableParameterError,

--- a/tests/integration/validation/test_validators.py
+++ b/tests/integration/validation/test_validators.py
@@ -32,7 +32,7 @@ class TestLocalOpenAPIv2Validator:
 
         validator.validate()
 
-        assert validator.is_valid() == True
+        assert validator.is_valid()
 
     @pytest.mark.parametrize(
         "spec_file",
@@ -49,7 +49,7 @@ class TestLocalOpenAPIv2Validator:
         with pytest.raises(OpenAPIValidationError):
             validator.validate()
 
-        assert validator.is_valid() == False
+        assert not validator.is_valid()
 
     @pytest.mark.parametrize(
         "spec_file",
@@ -90,7 +90,7 @@ class TestLocalOpenAPIv30Validator:
 
         validator.validate()
 
-        assert validator.is_valid() == True
+        assert validator.is_valid()
 
     @pytest.mark.parametrize(
         "spec_file",
@@ -107,7 +107,7 @@ class TestLocalOpenAPIv30Validator:
         with pytest.raises(OpenAPIValidationError):
             validator.validate()
 
-        assert validator.is_valid() == False
+        assert not validator.is_valid()
 
     @pytest.mark.parametrize(
         "spec_file",

--- a/tox.ini
+++ b/tox.ini
@@ -7,3 +7,7 @@ deps =
     -rrequirements_dev.txt
 commands =
     python setup.py test
+
+[flake8]
+max-line-length = 79
+extend-ignore = E203,E501,E701


### PR DESCRIPTION
This PR introduces the following changes:

* Fix deprecated pre-commit stage names.

  When `pre-commit install` is run, it currently throws a deprecation regarding the stage names in the config file. This is now fixed.

* Update the `pyupgrade` hook to its latest version, and update its target syntax version to Python 3.9+.

* Remove `flynt` as a pre-commit hook.

  Its functionality is handled by the `pyupgrade` hook.

* Migrate from `local` pre-commit hooks to standard, hosted pre-commit hooks.

  This change is necessary because not all git-related tooling runs pre-commit hooks with the same activated virtual environment that the Poetry dev dependencies are installed in.

Taken together, these changes bring the pre-commit hook configuration up-to-date, and make it possible to enable [pre-commit.ci](https://pre-commit.ci/) for the repo if you choose to do so (and I highly recommend doing so!).