### PR TITLE
Fix tox so that it can run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,12 @@
 [tox]
-envlist = {py37,py38,py39,py310}-{default,simplejson}
+envlist =
+    py{3.9,3.10,3.11,3.12,3.13}-{default,simplejson}
 
 [testenv]
+skip_install = true
 deps =
-    -rrequirements.txt
-    -rrequirements_dev.txt
+    poetry
+commands_pre =
+    poetry install --with dev
 commands =
-    python setup.py test
+    pytest


### PR DESCRIPTION
This PR introduces the following changes:

* It updates the tox config so that it can run.

  The `setup.py` file is gone, as are the `requirements.txt` files. Poetry is invoked to install the dependencies now.

* It updates the list of Python versions to run the test suite against.

Taken together, these changes allow developers to run the test suite locally before submitting PRs to the project.