### PR TITLE
Remove `hooks.yaml`, which is unused by pre-commit

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -1,6 +1,0 @@
-- id: openapi-spec-validator
-  name: openapi-spec-validator
-  entry: openapi-spec-validator
-  description: Hook to validate Open API specs.
-  language: python
-  files: .*openapi.*\.(json|yaml|yml)


### PR DESCRIPTION
pre-commit doesn't use `hooks.yaml` [[docs link](https://pre-commit.com/#creating-new-hooks)] -- it relies on `.pre-commit-hooks.yaml`.

Therefore this PR removes the unused `hooks.yaml` file.