### PR TITLE
Fix Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,12 +6,10 @@ sphinx:
 formats: all
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.13"
   jobs:
-    post_create_environment:
-      - pip install poetry
-      - poetry config virtualenvs.create false
     post_install:
-      - poetry install --with docs
+      - pip install poetry
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs


### PR DESCRIPTION
Read the Docs builds began permanently failing on February 26, 2024.

The differential diagnosis between success and failure seems to be that [the last successful build](https://app.readthedocs.org/projects/openapi-spec-validator/builds/23513651/#220526594--2) used Poetry 1.7.1; [the first failing build](https://app.readthedocs.org/projects/openapi-spec-validator/builds/23567051/#221127792--2) used Poetry 1.8.1. For reference, Poetry 1.8.1 was released on February 26, 2024.

Read the Docs later updated its ["Install dependencies with Poetry" documentation](https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-poetry) to note that Poetry needs a `$VIRTUAL_ENV` environment variable set.

This change aligns the Read the Docs config with the documented fix, and simultaneously updates the build OS and Python version, which are both very old.