### PR TITLE
Fix several typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Installation
 
 .. md-tab-set::
 
-   .. md-tab-item:: Pip + PyPI (recommented)
+   .. md-tab-item:: Pip + PyPI (recommended)
 
       .. code-block:: console
 

--- a/tests/integration/test_shortcuts.py
+++ b/tests/integration/test_shortcuts.py
@@ -56,7 +56,7 @@ class TestLiocalValidatev2Spec:
             "empty.yaml",
         ],
     )
-    def test_falied(self, factory, spec_file):
+    def test_failed(self, factory, spec_file):
         spec_path = self.local_test_suite_file_path(spec_file)
         spec = factory.spec_from_file(spec_path)
 
@@ -97,7 +97,7 @@ class TestLocalValidatev30Spec:
             "empty.yaml",
         ],
     )
-    def test_falied(self, factory, spec_file):
+    def test_failed(self, factory, spec_file):
         spec_path = self.local_test_suite_file_path(spec_file)
         spec = factory.spec_from_file(spec_path)
 


### PR DESCRIPTION
Found and fixed by running `typos` against the codebase.