### PR TITLE
Remove `MANIFEST.in`, which is unused by Poetry

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include README.md
-include requirements.txt
-include requirements_dev.txt
-include openapi_spec_validator/py.typed
-include openapi_spec_validator/resources/schemas/*/*
-include LICENSE


### PR DESCRIPTION
`MANIFEST.in` is unused by Poetry.

`poetry build`, as well as `python -m build`, were run to validate before-and-after that non-Python files and resources -- like the `py.typed` file and the JSON schema files -- were still included in the `.tar.gz` and `.whl` files.