### PR TITLE
Fix malformed schema traversal to report validation errors instead of…

### DIFF
--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -193,6 +193,34 @@ def test_schema_stdin(capsys):
     assert "stdin: OK\n" in out
 
 
+def test_malformed_schema_stdin(capsys):
+    """Malformed schema from STDIN reports validation error."""
+    spec_io = StringIO(
+        """
+openapi: 3.1.0
+info:
+  version: "1"
+  title: "Title"
+components:
+  schemas:
+    Component:
+      type: object
+      properties:
+        name: string
+"""
+    )
+
+    testargs = ["--schema", "3.1.0", "-"]
+    with mock.patch("openapi_spec_validator.__main__.sys.stdin", spec_io):
+        with pytest.raises(SystemExit):
+            main(testargs)
+
+    out, err = capsys.readouterr()
+    assert not err
+    assert "stdin: Validation Error:" in out
+    assert "stdin: OK" not in out
+
+
 def test_version(capsys):
     """Test --version flag outputs correct version."""
     testargs = ["--version"]


### PR DESCRIPTION
… internal exceptions

I reproduced this and implemented a fix on master branch locally.
Root cause:
- SchemaValidator recursively traversed schema nodes assuming mapping-like behavior.
- For malformed nodes like properties: {name: "string"}, that assumption could trigger internal exceptions (or produce poor UX depending on dependency versions), and in some cases even miss the error.
What was changed:
- In openapi_spec_validator/validation/keywords.py, SchemaValidator.__call__ now validates each schema node with check_schema(...) before descending into keywords like allOf / properties.
- If a node is malformed, we now yield OpenAPIValidationError and stop traversing that node.
- This avoids internal AttributeError paths and consistently reports a proper validation error.
Tests added:
- tests/integration/validation/test_exceptions.py
  - Added regression for malformed property schema (name: "string") and assert it emits OpenAPIValidationError.
- tests/integration/test_main.py
  - Added CLI regression using stdin for the same malformed input and assert output is Validation Error (and not OK).

Fixes #436