### PR TITLE
Split CLI error controls into validation and subschema modes

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -23,27 +23,48 @@ CLI (Command Line Interface)
 
          docker run -v path/to/openapi.yaml:/openapi.yaml --rm pythonopenapi/openapi-spec-validator /openapi.yaml
 
+      Show all validation errors:
+
+      .. code-block:: bash
+
+         docker run -v path/to/openapi.yaml:/openapi.yaml --rm pythonopenapi/openapi-spec-validator --validation-errors all /openapi.yaml
+
+      Show all validation errors and all subschema details:
+
+      .. code-block:: bash
+
+         docker run -v path/to/openapi.yaml:/openapi.yaml --rm pythonopenapi/openapi-spec-validator --validation-errors all --subschema-errors all /openapi.yaml
+
    .. md-tab-item:: Python interpreter
 
       .. code-block:: bash
 
          python -m openapi_spec_validator openapi.yaml
 
-.. code-block:: bash
+.. code-block:: text
 
-   usage: openapi-spec-validator [-h] [--errors {best-match,all}]
-                                 [--schema {2.0,3.0.0,3.1.0,detect}]
-                                 filename
+   usage: openapi-spec-validator [-h] [--subschema-errors {best-match,all}]
+                                 [--validation-errors {first,all}]
+                                 [--errors {best-match,all}] [--schema {detect,2.0,3.0,3.1}]
+                                 [--version] file [file ...]
    
    positional arguments:
-     filename              Absolute or relative path to file
+     file                  Validate specified file(s).
    
    options:
      -h, --help            show this help message and exit
-     --errors {best-match,all}
-                           Control error reporting. Defaults to "best-
-                           match", use "all" to get all subschema
-                           errors.
-     --schema {2.0,3.0.0,3.1.0,detect}
-                           OpenAPI schema (default: detect)
+     --subschema-errors {best-match,all}
+                           Control subschema error details. Defaults to "best-match",
+                           use "all" to get all subschema errors.
+     --validation-errors {first,all}
+                           Control validation errors count. Defaults to "first",
+                           use "all" to get all validation errors.
+     --errors {best-match,all}, --error {best-match,all}
+                           Deprecated alias for --subschema-errors.
+     --schema {detect,2.0,3.0,3.1}
+                           OpenAPI schema version (default: detect).
+     --version             show program's version number and exit
 
+Legacy note:
+   ``--errors`` / ``--error`` are deprecated and emit warnings by default.
+   Set ``OPENAPI_SPEC_VALIDATOR_WARN_DEPRECATED=0`` to silence warnings.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,10 @@ Usage
 
                docker run -v path/to/openapi.yaml:/openapi.yaml --rm pythonopenapi/openapi-spec-validator /openapi.yaml
 
+             .. code-block:: bash
+
+                docker run -v path/to/openapi.yaml:/openapi.yaml --rm pythonopenapi/openapi-spec-validator --validation-errors all /openapi.yaml
+
          .. md-tab-item:: Python interpreter
 
             .. code-block:: bash

--- a/openapi_spec_validator/validation/__init__.py
+++ b/openapi_spec_validator/validation/__init__.py
@@ -7,6 +7,7 @@ from openapi_spec_validator.validation.validators import (
 from openapi_spec_validator.validation.validators import (
     OpenAPIV31SpecValidator,
 )
+from openapi_spec_validator.validation.validators import SpecValidator
 
 __all__ = [
     "openapi_v2_spec_validator",
@@ -18,6 +19,7 @@ __all__ = [
     "OpenAPIV3SpecValidator",
     "OpenAPIV30SpecValidator",
     "OpenAPIV31SpecValidator",
+    "SpecValidator",
 ]
 
 # v2.0 spec


### PR DESCRIPTION
Deprecates `--error`/`--errors` options

Fixes #433
