### PR TITLE
test: add Xquik OpenAPI 3.1 fixture

### DIFF
--- a/tests/integration/data/v3.1/xquik-search.yaml
+++ b/tests/integration/data/v3.1/xquik-search.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: "1.0"
+servers:
+  - url: https://xquik.com
+paths:
+  /api/v1/x/tweets/search:
+    get:
+      operationId: searchTweets
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Search results.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchTweetsResponse"
+      security:
+        - apiKey: []
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    SearchTweetsResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tweet"
+    Tweet:
+      type: object
+      required:
+        - id
+        - text
+        - authorUsername
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+        authorUsername:
+          type: string

--- a/tests/integration/test_shortcuts.py
+++ b/tests/integration/test_shortcuts.py
@@ -6,9 +6,11 @@ import pytest
 from openapi_spec_validator import OpenAPIV2SpecValidator
 from openapi_spec_validator import OpenAPIV3SpecValidator
 from openapi_spec_validator import OpenAPIV30SpecValidator
+from openapi_spec_validator import OpenAPIV31SpecValidator
 from openapi_spec_validator import OpenAPIV32SpecValidator
 from openapi_spec_validator import openapi_v2_spec_validator
 from openapi_spec_validator import openapi_v30_spec_validator
+from openapi_spec_validator import openapi_v31_spec_validator
 from openapi_spec_validator import openapi_v32_spec_validator
 from openapi_spec_validator import schemas as schemas_module
 from openapi_spec_validator import shortcuts as shortcuts_module
@@ -223,6 +225,31 @@ class TestLocalValidatev30Spec:
         with pytest.warns(DeprecationWarning):
             with pytest.raises(OpenAPIValidationError):
                 validate_spec(spec, validator=openapi_v30_spec_validator)
+
+
+class TestLocalValidatev31Spec:
+    LOCAL_SOURCE_DIRECTORY = "data/v3.1/"
+
+    def local_test_suite_file_path(self, test_file):
+        return f"{self.LOCAL_SOURCE_DIRECTORY}{test_file}"
+
+    @pytest.mark.parametrize(
+        "spec_file",
+        [
+            "xquik-search.yaml",
+        ],
+    )
+    def test_valid(self, factory, spec_file):
+        spec_path = self.local_test_suite_file_path(spec_file)
+        spec = factory.spec_from_file(spec_path)
+        spec_url = factory.spec_file_url(spec_path)
+
+        validate(spec)
+        with pytest.warns(DeprecationWarning):
+            validate_spec(spec, spec_url=spec_url)
+        validate(spec, cls=OpenAPIV31SpecValidator)
+        with pytest.warns(DeprecationWarning):
+            validate_spec(spec, validator=openapi_v31_spec_validator)
 
 
 class TestLocalValidatev32Spec:


### PR DESCRIPTION
## Summary

- Add a compact OpenAPI 3.1 fixture for the Xquik search endpoint.
- Cover shortcut auto-detection, the explicit 3.1 validator class, and the deprecated 3.1 shortcut proxy.

## Validation

- `uv run` with Python 3.13 for `tests/integration/test_shortcuts.py -k xquik`: 1 passed.
