### PR TITLE
fix: wrap unresolvable $ref in ValidationError

### DIFF
--- a/openapi_spec_validator/validation/validators.py
+++ b/openapi_spec_validator/validation/validators.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 from functools import lru_cache
 from typing import cast
 
+from referencing.exceptions import Unresolvable
+
 from jsonschema.exceptions import ValidationError
 from jsonschema.protocols import Validator
 from jsonschema_path.handlers import default_handlers
@@ -69,11 +71,17 @@ class SpecValidator:
         )
 
     def validate(self) -> None:
-        for err in self.iter_errors():
-            raise err
+        try:
+            for err in self.iter_errors():
+                raise err
+        except Unresolvable as exc:
+            raise ValidationError(str(exc)) from exc
 
     def is_valid(self) -> bool:
-        error = next(self.iter_errors(), None)
+        try:
+            error = next(self.iter_errors(), None)
+        except Unresolvable:
+            return False
         return error is None
 
     @property

--- a/tests/integration/validation/test_validators.py
+++ b/tests/integration/validation/test_validators.py
@@ -1,4 +1,5 @@
 import pytest
+from jsonschema.exceptions import ValidationError
 from jsonschema_path import SchemaPath
 from referencing.exceptions import Unresolvable
 
@@ -65,7 +66,7 @@ class TestLocalOpenAPIv2Validator:
         spec = factory.spec_from_file(spec_path)
         spec_url = factory.spec_file_url(spec_path)
 
-        with pytest.raises(Unresolvable):
+        with pytest.raises(ValidationError):
             OpenAPIV2SpecValidator(spec, base_uri=spec_url).validate()
 
 
@@ -177,7 +178,7 @@ class TestLocalOpenAPIv30Validator:
         spec = factory.spec_from_file(spec_path)
         spec_url = factory.spec_file_url(spec_path)
 
-        with pytest.raises(Unresolvable):
+        with pytest.raises(ValidationError):
             OpenAPIV30SpecValidator(spec, base_uri=spec_url).validate()
 
 


### PR DESCRIPTION
## Problem

When a `$ref` points to a nonexistent target, `referencing.exceptions.Unresolvable` (`PointerToNowhere`) escapes uncaught instead of being wrapped in a `ValidationError`. The internal library exception leaks to the caller, and as a side effect dumps the entire spec into the error message.

## Reproduction (from #511)

```python
from openapi_spec_validator import validate
spec = {
    "openapi": "3.0.0",
    "info": {"title": "Test", "version": "1.0.0"},
    "paths": {"/test": {"get": {"responses": {
        "200": {"description": "ok"},
        "404": {"$ref": "#/components/responses/NotFound"},
    }}}}
}
validate(spec)
# Raises: referencing.exceptions.PointerToNowhere (not ValidationError)
```

## Cause

The `Unresolvable` exception escapes during `iter_errors()` generation (when a `$ref` is resolved), so the `wraps_errors` decorator — which only wraps *yielded* errors — doesn't catch it.

## Fix

Catch `referencing.exceptions.Unresolvable` in `SpecValidator.validate()` and `SpecValidator.is_valid()`:
- `validate()`: wrap in `jsonschema.exceptions.ValidationError`
- `is_valid()`: return `False` (the spec is invalid)

## Test

Updated the existing `test_ref_failed` tests (v2 + v3.1 parametrized) to expect `ValidationError` (the documented behavior) instead of `Unresolvable` (the leak). 45/45 integration tests pass.

Fixes #511.

Assisted-by: Claude (Anthropic).
